### PR TITLE
Add initWithName:rootPath:

### DIFF
--- a/TMCache/TMCache.h
+++ b/TMCache/TMCache.h
@@ -62,7 +62,7 @@ typedef void (^TMCacheObjectBlock)(TMCache *cache, NSString *key, id object);
 + (instancetype)sharedCache;
 
 /**
- The designated initializer. Multiple instances with the same name are allowed and can safely access
+ Multiple instances with the same name are allowed and can safely access
  the same data on disk thanks to the magic of seriality. Also used to create the <diskCache>.
  
  @see name
@@ -70,6 +70,17 @@ typedef void (^TMCacheObjectBlock)(TMCache *cache, NSString *key, id object);
  @result A new cache with the specified name.
  */
 - (instancetype)initWithName:(NSString *)name;
+
+/**
+ The designated initializer. Multiple instances with the same name are allowed and can safely access
+ the same data on disk thanks to the magic of seriality. Also used to create the <diskCache>.
+ 
+ @see name
+ @param name The name of the cache.
+ @param rootPath The path of the cache on disk.
+ @result A new cache with the specified name.
+ */
+- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath;
 
 #pragma mark -
 /// @name Asynchronous Methods

--- a/TMCache/TMCache.m
+++ b/TMCache/TMCache.m
@@ -25,6 +25,11 @@ NSString * const TMCacheSharedName = @"TMCacheShared";
 
 - (instancetype)initWithName:(NSString *)name
 {
+    return [self initWithName:name rootPath:[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex:0]];
+}
+
+- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath
+{
     if (!name)
         return nil;
 
@@ -34,7 +39,7 @@ NSString * const TMCacheSharedName = @"TMCacheShared";
         NSString *queueName = [[NSString alloc] initWithFormat:@"%@.%p", TMCachePrefix, self];
         _queue = dispatch_queue_create([queueName UTF8String], DISPATCH_QUEUE_CONCURRENT);
 
-        _diskCache = [[TMDiskCache alloc] initWithName:_name];
+        _diskCache = [[TMDiskCache alloc] initWithName:_name rootPath:rootPath];
         _memoryCache = [[TMMemoryCache alloc] init];
     }
     return self;

--- a/TMCache/TMDiskCache.h
+++ b/TMCache/TMDiskCache.h
@@ -133,7 +133,7 @@ typedef void (^TMDiskCacheObjectBlock)(TMDiskCache *cache, NSString *key, id <NS
 + (dispatch_queue_t)sharedQueue;
 
 /**
- The designated initializer. Multiple instances with the same name are allowed and can safely access
+ Multiple instances with the same name are allowed and can safely access
  the same data on disk thanks to the magic of seriality.
  
  @see name
@@ -141,6 +141,17 @@ typedef void (^TMDiskCacheObjectBlock)(TMDiskCache *cache, NSString *key, id <NS
  @result A new cache with the specified name.
  */
 - (instancetype)initWithName:(NSString *)name;
+
+/**
+ The designated initializer. Multiple instances with the same name are allowed and can safely access
+ the same data on disk thanks to the magic of seriality.
+ 
+ @see name
+ @param name The name of the cache.
+ @param rootPath The path of the cache.
+ @result A new cache with the specified name.
+ */
+- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath;
 
 #pragma mark -
 /// @name Asynchronous Methods

--- a/TMCache/TMDiskCache.m
+++ b/TMCache/TMDiskCache.m
@@ -40,6 +40,11 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
 
 - (instancetype)initWithName:(NSString *)name
 {
+    return [self initWithName:name rootPath:[NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES) objectAtIndex:0]];
+}
+
+- (instancetype)initWithName:(NSString *)name rootPath:(NSString *)rootPath
+{
     if (!name)
         return nil;
 
@@ -61,9 +66,8 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
         _dates = [[NSMutableDictionary alloc] init];
         _sizes = [[NSMutableDictionary alloc] init];
 
-        NSArray *paths = NSSearchPathForDirectoriesInDomains(NSCachesDirectory, NSUserDomainMask, YES);
         NSString *pathComponent = [[NSString alloc] initWithFormat:@"%@.%@", TMDiskCachePrefix, _name];
-        _cacheURL = [NSURL fileURLWithPathComponents:@[ [paths objectAtIndex:0], pathComponent ]];
+        _cacheURL = [NSURL fileURLWithPathComponents:@[ rootPath, pathComponent ]];
 
         __weak TMDiskCache *weakSelf = self;
 


### PR DESCRIPTION
Used to store the cache in a different directory than the NSCachesDirectory (an offline data folder for example).
