### PR TITLE
Resolves deadlock issues by making synchronous objectForKey: methods truly synchronous

### DIFF
--- a/TMCache/TMCache.m
+++ b/TMCache/TMCache.m
@@ -71,45 +71,7 @@ NSString * const TMCacheSharedName = @"TMCacheShared";
         if (!strongSelf)
             return;
 
-        __weak TMCache *weakSelf = strongSelf;
-        
-        [strongSelf->_memoryCache objectForKey:key block:^(TMMemoryCache *cache, NSString *key, id object) {
-            TMCache *strongSelf = weakSelf;
-            if (!strongSelf)
-                return;
-            
-            if (object) {
-                [strongSelf->_diskCache fileURLForKey:key block:^(TMDiskCache *cache, NSString *key, id <NSCoding> object, NSURL *fileURL) {
-                    // update the access time on disk
-                }];
-
-                __weak TMCache *weakSelf = strongSelf;
-                
-                dispatch_async(strongSelf->_queue, ^{
-                    TMCache *strongSelf = weakSelf;
-                    if (strongSelf)
-                        block(strongSelf, key, object);
-                });
-            } else {
-                __weak TMCache *weakSelf = strongSelf;
-
-                [strongSelf->_diskCache objectForKey:key block:^(TMDiskCache *cache, NSString *key, id <NSCoding> object, NSURL *fileURL) {
-                    TMCache *strongSelf = weakSelf;
-                    if (!strongSelf)
-                        return;
-                    
-                    [strongSelf->_memoryCache setObject:object forKey:key block:nil];
-                    
-                    __weak TMCache *weakSelf = strongSelf;
-                    
-                    dispatch_async(strongSelf->_queue, ^{
-                        TMCache *strongSelf = weakSelf;
-                        if (strongSelf)
-                            block(strongSelf, key, object);
-                    });
-                }];
-            }
-        }];
+        block(strongSelf, key, [strongSelf objectForKey:key]);
     });
 }
 

--- a/TMCache/TMDiskCache.m
+++ b/TMCache/TMDiskCache.m
@@ -385,8 +385,6 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
 
 - (void)objectForKey:(NSString *)key block:(TMDiskCacheObjectBlock)block
 {
-    NSDate *now = [[NSDate alloc] init];
-
     if (!key || !block)
         return;
 
@@ -398,14 +396,7 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
             return;
 
         NSURL *fileURL = [strongSelf encodedFileURLForKey:key];
-        id <NSCoding> object = nil;
-
-        if ([[NSFileManager defaultManager] fileExistsAtPath:[fileURL path]]) {
-            object = [NSKeyedUnarchiver unarchiveObjectWithFile:[fileURL path]];
-            [strongSelf setFileModificationDate:now forURL:fileURL];
-        }
-
-        block(strongSelf, key, object, fileURL);
+        block(strongSelf, key, [strongSelf objectForKey:key], fileURL);
     });
 }
 

--- a/TMCache/TMMemoryCache.m
+++ b/TMCache/TMMemoryCache.m
@@ -451,8 +451,6 @@ NSString * const TMMemoryCachePrefix = @"com.tumblr.TMMemoryCache";
     if (!key)
         return nil;
     
-    NSDate *now = [[NSDate alloc] init];
-    
     id object = [_dictionary objectForKey:key];
     
     if (object) {
@@ -460,7 +458,7 @@ NSString * const TMMemoryCachePrefix = @"com.tumblr.TMMemoryCache";
         dispatch_barrier_async(_queue, ^{
             TMMemoryCache *strongSelf = weakSelf;
             if (strongSelf)
-                [strongSelf->_dates setObject:now forKey:key];
+                [strongSelf->_dates setObject:[NSDate new] forKey:key];
         });
     }
     

--- a/TMCache/TMMemoryCache.m
+++ b/TMCache/TMMemoryCache.m
@@ -225,8 +225,6 @@ NSString * const TMMemoryCachePrefix = @"com.tumblr.TMMemoryCache";
 
 - (void)objectForKey:(NSString *)key block:(TMMemoryCacheObjectBlock)block
 {
-    NSDate *now = [[NSDate alloc] init];
-    
     if (!key || !block)
         return;
 
@@ -237,18 +235,7 @@ NSString * const TMMemoryCachePrefix = @"com.tumblr.TMMemoryCache";
         if (!strongSelf)
             return;
 
-        id object = [strongSelf->_dictionary objectForKey:key];
-
-        if (object) {
-            __weak TMMemoryCache *weakSelf = strongSelf;
-            dispatch_barrier_async(strongSelf->_queue, ^{
-                TMMemoryCache *strongSelf = weakSelf;
-                if (strongSelf)
-                    [strongSelf->_dates setObject:now forKey:key];
-            });
-        }
-
-        block(strongSelf, key, object);
+        block(strongSelf, key, [strongSelf objectForKey:key]);
     });
 }
 


### PR DESCRIPTION
Also refactors async objectForKey:block: to use synchronous objectForKey: counterparts. Speed improvements by reducing number of dispatched threads, dropping unnecessary calls, postponing object instantiation.
