### PR TITLE
prevent crash when disk cache file is corrupted

### DIFF
--- a/TMCache/TMDiskCache.m
+++ b/TMCache/TMDiskCache.m
@@ -413,7 +413,15 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
         id <NSCoding> object = nil;
 
         if ([[NSFileManager defaultManager] fileExistsAtPath:[fileURL path]]) {
-            object = [NSKeyedUnarchiver unarchiveObjectWithFile:[fileURL path]];
+            @try {
+                object = [NSKeyedUnarchiver unarchiveObjectWithFile:[fileURL path]];
+            }
+            @catch (NSException *exception) {
+                NSError *error = nil;
+                [[NSFileManager defaultManager] removeItemAtPath:[fileURL path] error:&error];
+                TMDiskCacheError(error);
+            }
+
             [strongSelf setFileModificationDate:now forURL:fileURL];
         }
 


### PR DESCRIPTION
We have received several crash reports related to TMDiskCache like below:

```
Application Specific Information:
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[NSKeyedUnarchiver initForReadingWithData:]: incomprehensible archive (0x62, 0x70, 0x6c, 0x69, 0x73, 0x74, 0x30, 0x30)'

Last Exception Backtrace:
0 CoreFoundation 0x3377b3e7 0x336b9000 + 795623
1 libobjc.A.dylib 0x3b5fb963 0x3b5f3000 + 35171
2 CoreFoundation 0x3377b307 0x336b9000 + 795399
3 Foundation 0x340139d1 0x33fe2000 + 203217
4 Foundation 0x340749df 0x33fe2000 + 600543
5 XXXX 0x00ac8183 __34-[TMDiskCache objectForKey:block:]_block_invoke (in XXXX) (TMDiskCache.m:416)
6 libdispatch.dylib 0x3ba15793 0x3ba14000 + 6035
7 libdispatch.dylib 0x3ba18b3b 0x3ba14000 + 19259
8 libdispatch.dylib 0x3ba1667d 0x3ba14000 + 9853
9 libdispatch.dylib 0x3ba19613 0x3ba14000 + 22035
10 libdispatch.dylib 0x3ba197d9 0x3ba14000 + 22489
11 libsystem_c.dylib 0x3ba3d7f1 0x3ba37000 + 26609
12 libsystem_c.dylib 0x3ba3d684 0x3ba37000 + 26244
```

It is because the users' cache file is somehow corrupted and It seems the line crashed `object = [NSKeyedUnarchiver unarchiveObjectWithFile:[fileURL path]];` needs a try catch block to prevent crash when this happens.
