### PR TITLE
CocoaPods 0.34 Compatibility

### DIFF
--- a/TMCache.podspec
+++ b/TMCache.podspec
@@ -13,23 +13,4 @@ Pod::Spec.new do |s|
   s.osx.weak_frameworks   = 'AppKit'
   s.ios.deployment_target = '5.0'
   s.osx.deployment_target = '10.7'
-  s.documentation = {
-    :html => 'http://cocoadocs.org/docsets/TMCache/',
-    :appledoc => [
-      '--company-id', 'com.tumblr',
-      '--project-name', 'TMCache',
-      '--project-company', 'Tumblr',
-      '--project-version', '1.2.1',
-      '--docset-min-xcode-version', '4.3',
-      '--docset-bundle-name', '%PROJECT %VERSION',
-      '--docset-bundle-id', '%COMPANYID.%PROJECTID',
-      '--docset-bundle-filename', '%COMPANYID.%PROJECTID-%VERSIONID.docset',
-      '--ignore', 'tests',
-      '--ignore', 'docs',
-      '--ignore', '*.m',
-      '--no-repeat-first-par',
-      '--explicit-crossref',
-      '--clean-output'
-    ]
-  }
 end


### PR DESCRIPTION
Removes deprecated documentation field that now errors instead of throwing a warning.
