### PR TITLE
TMDiskCache trash directory creation on the calling thread

### DIFF
--- a/TMCache/TMDiskCache.m
+++ b/TMCache/TMDiskCache.m
@@ -178,16 +178,14 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
     dispatch_once(&predicate, ^{
         sharedTrashURL = [[[NSURL alloc] initFileURLWithPath:NSTemporaryDirectory()] URLByAppendingPathComponent:TMDiskCachePrefix isDirectory:YES];
         
-        dispatch_async([self sharedTrashQueue], ^{
-            if (![[NSFileManager defaultManager] fileExistsAtPath:[sharedTrashURL path]]) {
-                NSError *error = nil;
-                [[NSFileManager defaultManager] createDirectoryAtURL:sharedTrashURL
-                                         withIntermediateDirectories:YES
-                                                          attributes:nil
-                                                               error:&error];
-                TMDiskCacheError(error);
-            }
-        });
+        if (![[NSFileManager defaultManager] fileExistsAtPath:[sharedTrashURL path]]) {
+            NSError *error = nil;
+            [[NSFileManager defaultManager] createDirectoryAtURL:sharedTrashURL
+                                     withIntermediateDirectories:YES
+                                                      attributes:nil
+                                                           error:&error];
+            TMDiskCacheError(error);
+        }
     });
     
     return sharedTrashURL;


### PR DESCRIPTION
Having the trash directory creation happening asynchronously leads to a race condition and potential crash on slower hardware.
One of my test cases run against iPhone 4 failed consistently in TMDiskCache.m line 205 with Cocoa error 4 because the temp directory was not yet created when consumed for the first time.
This is one time, quick operation and the temp directory has to be readily available when sharedTrashURL returns control on the calling thread?
