### PR TITLE
- Use dispatch_sync when creating the trash directory for the first time...

### DIFF
--- a/TMCache/TMDiskCache.m
+++ b/TMCache/TMDiskCache.m
@@ -178,7 +178,7 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
     dispatch_once(&predicate, ^{
         sharedTrashURL = [[[NSURL alloc] initFileURLWithPath:NSTemporaryDirectory()] URLByAppendingPathComponent:TMDiskCachePrefix isDirectory:YES];
         
-        dispatch_async([self sharedTrashQueue], ^{
+        dispatch_sync([self sharedTrashQueue], ^{
             if (![[NSFileManager defaultManager] fileExistsAtPath:[sharedTrashURL path]]) {
                 NSError *error = nil;
                 [[NSFileManager defaultManager] createDirectoryAtURL:sharedTrashURL


### PR DESCRIPTION
If dispatch_async is used, first access to + (NSURL *)sharedTrashURL will return a NSURL which points to a non-existing directory, which will cause errors in removing objects from disk cache
