### PR TITLE
Fix deadlocking issues in TMMemoryCache related to thread starvation

### DIFF
--- a/TMCache/TMCache.h
+++ b/TMCache/TMCache.h
@@ -36,7 +36,7 @@ typedef void (^TMCacheObjectBlock)(TMCache *cache, NSString *key, id object);
 /**
  A concurrent queue on which blocks passed to the asynchronous access methods are run.
  */
-@property (readonly) dispatch_queue_t queue;
+@property (readonly) dispatch_queue_t asyncQueue;
 
 /**
  Synchronously retrieves the total byte count of the <diskCache> on the shared disk queue.

--- a/TMCache/TMMemoryCache.m
+++ b/TMCache/TMMemoryCache.m
@@ -7,11 +7,12 @@
 NSString * const TMMemoryCachePrefix = @"com.tumblr.TMMemoryCache";
 
 @interface TMMemoryCache ()
-@property (strong, nonatomic) dispatch_semaphore_t lock;
 #if OS_OBJECT_USE_OBJC
 @property (strong, nonatomic) dispatch_queue_t queue;
+@property (strong, nonatomic) dispatch_semaphore_t lock;
 #else
 @property (assign, nonatomic) dispatch_queue_t queue;
+@property (assign, nonatomic) dispatch_semaphore_t lock;
 #endif
 @property (strong, nonatomic) NSMutableDictionary *dictionary;
 @property (strong, nonatomic) NSMutableDictionary *dates;

--- a/tests/TMCacheTests/TMCacheTests.m
+++ b/tests/TMCacheTests/TMCacheTests.m
@@ -335,12 +335,15 @@ NSTimeInterval TMCacheTestBlockTimeout = 5.0;
     [self.cache setObject:[self image] forKey:key];
     dispatch_queue_t testQueue = dispatch_queue_create("test queue", DISPATCH_QUEUE_CONCURRENT);
     
+    NSLock *enumCountLock = [[NSLock alloc] init];
     __block NSUInteger enumCount = 0;
     dispatch_group_t group = dispatch_group_create();
     for (NSUInteger idx = 0; idx < objectCount; idx++) {
         dispatch_group_async(group, testQueue, ^{
             [self.cache objectForKey:key];
+            [enumCountLock lock];
             enumCount++;
+            [enumCountLock unlock];
         });
     }
     

--- a/tests/TMCacheTests/TMCacheTests.m
+++ b/tests/TMCacheTests/TMCacheTests.m
@@ -307,7 +307,7 @@ NSTimeInterval TMCacheTestBlockTimeout = 5.0;
     dispatch_apply(objectCount, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(size_t index) {
         NSString *key = [[NSString alloc] initWithFormat:@"key %zd", index];
         NSString *obj = [[NSString alloc] initWithFormat:@"obj %zd", index];
-        [self.cache.diskCache setObject:obj forKey:key block:nil];
+        [self.cache.diskCache setObject:obj forKey:key];
     });
 
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);

--- a/tests/TMCacheTests/TMCacheTests.m
+++ b/tests/TMCacheTests/TMCacheTests.m
@@ -275,7 +275,7 @@ NSTimeInterval TMCacheTestBlockTimeout = 5.0;
     dispatch_apply(objectCount, dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(size_t index) {
         NSString *key = [[NSString alloc] initWithFormat:@"key %zd", index];
         NSString *obj = [[NSString alloc] initWithFormat:@"obj %zd", index];
-        [self.cache.memoryCache setObject:obj forKey:key block:nil];
+        [self.cache.memoryCache setObject:obj forKey:key];
     });
 
     self.cache.memoryCache.removeAllObjectsOnMemoryWarning = NO;


### PR DESCRIPTION
1. Re-architected everything to be synchronous by default and asynchronous methods are simply wrapped versions of the synchronous ones.
2. Changed TMMemoryCache to use pthread_locks instead of dispatch_queues to protect resources (this is where we lose our performance, context switching is faster than locks).
3. Added an integration test which shows the deadlocking (but passes with the above changes).

This results in a slight performance degradation, but it resolves deadlocking issues. Would love to get feedback on this or hear other ideas for resolving the issue.
