### PR TITLE
Fixed the issue: cache life time (per object) #65

### DIFF
--- a/TMCache/TMCache.h
+++ b/TMCache/TMCache.h
@@ -107,6 +107,18 @@ typedef void (^TMCacheObjectBlock)(TMCache *cache, NSString *key, id object);
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(TMCacheObjectBlock)block;
 
 /**
+ Stores an object in the cache for the specified key. This method returns immediately and executes the
+ passed block after the object has been stored, potentially in parallel with other blocks on the <queue>. 
+ The object will be removed from cache after it's life (in seconds) is expired.
+ 
+ @param object An object to store in the cache.
+ @param key A key to associate with the object. This string will be copied.
+ @param life Expected interval (in seconds) for which the object should live in cache.
+ @param block A block to be executed concurrently after the object has been stored, or nil.
+ */
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key andLife:(NSUInteger)life block:(TMCacheObjectBlock)block;
+
+/**
  Removes the object for the specified key. This method returns immediately and executes the passed
  block after the object has been removed, potentially in parallel with other blocks on the <queue>.
  
@@ -152,6 +164,17 @@ typedef void (^TMCacheObjectBlock)(TMCache *cache, NSString *key, id object);
  @param key A key to associate with the object. This string will be copied.
  */
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key;
+
+/**
+ Stores an object in the cache for the specified key. This method blocks the calling thread until the
+ object has been set. The object will be removed from cache after it's life (in seconds) is expired.
+ 
+ @see setObject:forKey:block:
+ @param object An object to store in the cache.
+ @param key A key to associate with the object. This string will be copied.
+ @param life Expected interval (in seconds) for which the object should live in cache.
+ */
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key andLife:(NSUInteger)life;
 
 /**
  Removes the object for the specified key. This method blocks the calling thread until the object

--- a/TMCache/TMDiskCache.h
+++ b/TMCache/TMDiskCache.h
@@ -199,6 +199,18 @@ typedef void (^TMDiskCacheObjectBlock)(TMDiskCache *cache, NSString *key, id <NS
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(TMDiskCacheObjectBlock)block;
 
 /**
+ Stores an object in the cache for the specified key. This method returns immediately and executes the
+ passed block as soon as the object has been stored. The object will be removed from cache after it's 
+ life (in seconds) is expired.
+ 
+ @param object An object to store in the cache.
+ @param key A key to associate with the object. This string will be copied.
+ @param life Expected interval (in seconds) for which the object should live in cache.
+ @param block A block to be executed serially after the object has been stored, or nil.
+ */
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key andLife:(NSUInteger)life block:(TMDiskCacheObjectBlock)block;
+
+/**
  Removes the object for the specified key. This method returns immediately and executes the passed block
  as soon as the object has been removed.
  
@@ -286,6 +298,17 @@ typedef void (^TMDiskCacheObjectBlock)(TMDiskCache *cache, NSString *key, id <NS
  @param key A key to associate with the object. This string will be copied.
  */
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key;
+
+/**
+ Stores an object in the cache for the specified key. This method blocks the calling thread until
+ the object has been stored. The object will be removed from cache after it's life (in seconds) is expired.
+ 
+ @see setObject:forKey:block:
+ @param object An object to store in the cache.
+ @param key A key to associate with the object. This string will be copied.
+ @param life Expected interval (in seconds) for which the object should live in cache.
+ */
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key andLife:(NSUInteger)life;
 
 /**
  Removes the object for the specified key. This method blocks the calling thread until the object

--- a/TMCache/TMDiskCache.m
+++ b/TMCache/TMDiskCache.m
@@ -21,11 +21,15 @@
 NSString * const TMDiskCachePrefix = @"com.tumblr.TMDiskCache";
 NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
 
+//interval to check object life span, we can reduce it for more accuracy, but it might take toll on performance
+static NSTimeInterval const kExpiryCheckInterval = 1.0;
+
 @interface TMDiskCache ()
 @property (assign) NSUInteger byteCount;
 @property (strong, nonatomic) NSURL *cacheURL;
 @property (assign, nonatomic) dispatch_queue_t queue;
 @property (strong, nonatomic) NSMutableDictionary *dates;
+@property (strong, nonatomic) NSMutableDictionary *expiryDates;
 @property (strong, nonatomic) NSMutableDictionary *sizes;
 @end
 
@@ -69,6 +73,7 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
 
         _dates = [[NSMutableDictionary alloc] init];
         _sizes = [[NSMutableDictionary alloc] init];
+        _expiryDates = [[NSMutableDictionary alloc] init];
 
         NSString *pathComponent = [[NSString alloc] initWithFormat:@"%@.%@", TMDiskCachePrefix, _name];
         _cacheURL = [NSURL fileURLWithPathComponents:@[ rootPath, pathComponent ]];
@@ -324,11 +329,30 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
 
     [_sizes removeObjectForKey:key];
     [_dates removeObjectForKey:key];
+    [_expiryDates removeObjectForKey:key];
 
     if (_didRemoveObjectBlock)
         _didRemoveObjectBlock(self, key, nil, fileURL);
 
     return YES;
+}
+
+- (void)trimExpiredObjects
+{
+    NSArray *keysSortedByExpiryDate = [_expiryDates keysSortedByValueUsingSelector:@selector(compare:)];
+    NSDate *now = [NSDate date];
+    for (NSString *key in keysSortedByExpiryDate) { // oldest objects first
+        NSDate *expiryDate = [_expiryDates objectForKey:key];
+        if (!expiryDate)
+            continue;
+        
+        if ([expiryDate compare:now] == NSOrderedAscending) { // expired
+            [self removeFileAndExecuteBlocksForKey:key];
+        } else {
+            break;
+        }
+    }
+
 }
 
 - (void)trimDiskToSize:(NSUInteger)trimByteCount
@@ -392,6 +416,42 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
     dispatch_after(time, _queue, ^(void) {
         TMDiskCache *strongSelf = weakSelf;
         [strongSelf trimToAgeLimitRecursively];
+    });
+}
+
+- (void)trimExpiredObjectsRecursively
+{
+    if (_expiryDates.allKeys.count == 0)
+        return; // no object has an expiry date
+    
+    TMCacheStartBackgroundTask();
+    
+    __weak TMDiskCache *weakSelf = self;
+    
+    dispatch_async(_queue, ^{
+        TMDiskCache *strongSelf = weakSelf;
+        if (!strongSelf) {
+            TMCacheEndBackgroundTask();
+            return;
+        }
+        
+        [strongSelf trimExpiredObjects];
+        
+        TMCacheEndBackgroundTask();
+    });
+    
+    dispatch_time_t time = dispatch_time(DISPATCH_TIME_NOW, (int64_t)(kExpiryCheckInterval * NSEC_PER_SEC));
+    dispatch_after(time, _queue, ^(void){
+        TMDiskCache *strongSelf = weakSelf;
+        if (!strongSelf)
+            return;
+        
+        __weak TMDiskCache *weakSelf = strongSelf;
+        
+        dispatch_barrier_async(strongSelf->_queue, ^{
+            TMDiskCache *strongSelf = weakSelf;
+            [strongSelf trimExpiredObjectsRecursively];
+        });
     });
 }
 
@@ -459,6 +519,11 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
 
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key block:(TMDiskCacheObjectBlock)block
 {
+    [self setObject:object forKey:key andLife:0 block:block];
+}
+
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key andLife:(NSUInteger)life block:(TMDiskCacheObjectBlock)block
+{
     NSDate *now = [[NSDate alloc] init];
 
     if (!key || !object)
@@ -497,6 +562,15 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
             
             if (strongSelf->_byteLimit > 0 && strongSelf->_byteCount > strongSelf->_byteLimit)
                 [strongSelf trimToSizeByDate:strongSelf->_byteLimit block:nil];
+            
+            if (life > 0) {
+                NSDate *expiryDate = [[NSDate alloc] initWithTimeIntervalSinceNow:life];
+                [strongSelf->_expiryDates setObject:expiryDate forKey:key];
+                if (_expiryDates.allKeys.count == 1) { //this is the first key with expiry date
+                    [strongSelf trimExpiredObjectsRecursively];
+                }
+            }
+            
         } else {
             fileURL = nil;
         }
@@ -645,6 +719,8 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
         [strongSelf->_dates removeAllObjects];
         [strongSelf->_sizes removeAllObjects];
         strongSelf.byteCount = 0; // atomic
+        
+        [strongSelf->_expiryDates removeAllObjects];
 
         if (strongSelf->_didRemoveAllObjectsBlock)
             strongSelf->_didRemoveAllObjectsBlock(strongSelf);
@@ -736,12 +812,17 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
 
 - (void)setObject:(id <NSCoding>)object forKey:(NSString *)key
 {
+    [self setObject:object forKey:key andLife:0];
+}
+
+- (void)setObject:(id <NSCoding>)object forKey:(NSString *)key andLife:(NSUInteger)life
+{
     if (!object || !key)
         return;
     
     dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-    [self setObject:object forKey:key block:^(TMDiskCache *cache, NSString *key, id <NSCoding> object, NSURL *fileURL) {
+    
+    [self setObject:object forKey:key andLife:life block:^(TMDiskCache *cache, NSString *key, id <NSCoding> object, NSURL *fileURL) {
         dispatch_semaphore_signal(semaphore);
     }];
 

--- a/TMCache/TMMemoryCache.h
+++ b/TMCache/TMMemoryCache.h
@@ -159,6 +159,21 @@ typedef void (^TMMemoryCacheObjectBlock)(TMMemoryCache *cache, NSString *key, id
 - (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost block:(TMMemoryCacheObjectBlock)block;
 
 /**
+ Stores an object in the cache for the specified key and the specified cost. If the cost causes the total
+ to go over the <costLimit> the cache is trimmed (oldest objects first). The object will be removed from
+ cache after it's life (in seconds) is expired. This method returns immediately and executes the passed
+ block after the object has been stored, potentially in parallel with other blocks on the <queue>.
+ 
+ @param object An object to store in the cache.
+ @param key A key to associate with the object. This string will be copied.
+ @param cost An amount to add to the <totalCost>.
+ @param life Expected interval (in seconds) for which the object should live in cache.
+ @param block A block to be executed concurrently after the object has been stored, or nil.
+ */
+
+- (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost andLife:(NSUInteger)life block:(TMMemoryCacheObjectBlock)block;
+
+/**
  Removes the object for the specified key. This method returns immediately and executes the passed
  block after the object has been removed, potentially in parallel with other blocks on the <queue>.
  
@@ -247,6 +262,19 @@ typedef void (^TMMemoryCacheObjectBlock)(TMMemoryCache *cache, NSString *key, id
  @param cost An amount to add to the <totalCost>.
  */
 - (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost;
+
+/**
+ Stores an object in the cache for the specified key and the specified cost. If the cost causes the total
+ to go over the <costLimit> the cache is trimmed (oldest objects first). The object will be removed from
+ cache after it's life (in seconds) is expired. This method blocks the calling thread until the object has
+ been stored.
+ 
+ @param object An object to store in the cache.
+ @param key A key to associate with the object. This string will be copied.
+ @param cost An amount to add to the <totalCost>.
+ @param life Expected interval (in seconds) for which the object should live in cache.
+ */
+- (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost andLife:(NSUInteger)life;
 
 /**
  Removes the object for the specified key. This method blocks the calling thread until the object

--- a/TMCache/TMMemoryCache.m
+++ b/TMCache/TMMemoryCache.m
@@ -555,20 +555,7 @@ static NSTimeInterval const kExpiryCheckInterval = 1.0;
 
 - (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost
 {
-    if (!object || !key)
-        return;
-
-    dispatch_semaphore_t semaphore = dispatch_semaphore_create(0);
-
-    [self setObject:object forKey:key withCost:cost block:^(TMMemoryCache *cache, NSString *key, id object) {
-        dispatch_semaphore_signal(semaphore);
-    }];
-
-    dispatch_semaphore_wait(semaphore, DISPATCH_TIME_FOREVER);
-
-    #if !OS_OBJECT_USE_OBJC
-    dispatch_release(semaphore);
-    #endif
+    [self setObject:object forKey:key withCost:cost andLife:0];
 }
 
 - (void)setObject:(id)object forKey:(NSString *)key withCost:(NSUInteger)cost andLife:(NSUInteger)life


### PR DESCRIPTION
I added a new Dictionary 'expiryDates' to support this feature. My understanding of problem was to provide a kinda 'Kill Timer' to 'all' objects in cache. That means each object will have a lifetime (in seconds) when it would be kicked out of cache. So I bound the concept of Life (and Life Time in seconds) to generate an Expiry Date.
None of the existing three dictionaries are used to 'not to (or as minimal) touch existing code' at least for this first iteration. It can be later optimised for better solutions, but initially it should be cautious.