### PR TITLE
Conditionally compile references to UIApplication only when not building for an extension target

### DIFF
--- a/TMCache.podspec
+++ b/TMCache.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'TMCache'
-  s.version       = '1.2.3'
+  s.version       = '1.2.4'
   s.source_files  = 'TMCache/*.{h,m}'
   s.homepage      = 'https://github.com/tumblr/TMCache'
   s.summary       = 'Fast parallel object cache for iOS and OS X.'

--- a/TMCache/TMDiskCache.m
+++ b/TMCache/TMDiskCache.m
@@ -8,7 +8,7 @@
                                     [[NSString stringWithUTF8String:__FILE__] lastPathComponent], \
                                     __LINE__, [error localizedDescription]); }
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && !__has_feature(attribute_availability_app_extension)
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && defined(__clang) && defined(__has_feature) && !__has_feature(attribute_availability_app_extension)
     #define TMCacheStartBackgroundTask() UIBackgroundTaskIdentifier taskID = UIBackgroundTaskInvalid; \
             taskID = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{ \
             [[UIApplication sharedApplication] endBackgroundTask:taskID]; }];

--- a/TMCache/TMDiskCache.m
+++ b/TMCache/TMDiskCache.m
@@ -8,7 +8,7 @@
                                     [[NSString stringWithUTF8String:__FILE__] lastPathComponent], \
                                     __LINE__, [error localizedDescription]); }
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && !__has_feature(attribute_availability_app_extension)
     #define TMCacheStartBackgroundTask() UIBackgroundTaskIdentifier taskID = UIBackgroundTaskInvalid; \
             taskID = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{ \
             [[UIApplication sharedApplication] endBackgroundTask:taskID]; }];

--- a/TMCache/TMMemoryCache.m
+++ b/TMCache/TMMemoryCache.m
@@ -71,7 +71,7 @@ NSString * const TMMemoryCachePrefix = @"com.tumblr.TMMemoryCache";
         _removeAllObjectsOnMemoryWarning = YES;
         _removeAllObjectsOnEnteringBackground = YES;
 
-        #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && !__has_feature(attribute_availability_app_extension)
+        #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && defined(__clang) && defined(__has_feature) && !__has_feature(attribute_availability_app_extension)
         for (NSString *name in @[UIApplicationDidReceiveMemoryWarningNotification, UIApplicationDidEnterBackgroundNotification]) {
             [[NSNotificationCenter defaultCenter] addObserver:self
                                                      selector:@selector(didObserveApocalypticNotification:)
@@ -99,7 +99,7 @@ NSString * const TMMemoryCachePrefix = @"com.tumblr.TMMemoryCache";
 
 - (void)didObserveApocalypticNotification:(NSNotification *)notification
 {
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && !__has_feature(attribute_availability_app_extension)
+        #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && defined(__clang) && defined(__has_feature) && !__has_feature(attribute_availability_app_extension)
 
     if ([[notification name] isEqualToString:UIApplicationDidReceiveMemoryWarningNotification]) {
         if (self.removeAllObjectsOnMemoryWarning)

--- a/TMCache/TMMemoryCache.m
+++ b/TMCache/TMMemoryCache.m
@@ -71,7 +71,7 @@ NSString * const TMMemoryCachePrefix = @"com.tumblr.TMMemoryCache";
         _removeAllObjectsOnMemoryWarning = YES;
         _removeAllObjectsOnEnteringBackground = YES;
 
-        #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+        #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && !__has_feature(attribute_availability_app_extension)
         for (NSString *name in @[UIApplicationDidReceiveMemoryWarningNotification, UIApplicationDidEnterBackgroundNotification]) {
             [[NSNotificationCenter defaultCenter] addObserver:self
                                                      selector:@selector(didObserveApocalypticNotification:)
@@ -99,7 +99,7 @@ NSString * const TMMemoryCachePrefix = @"com.tumblr.TMMemoryCache";
 
 - (void)didObserveApocalypticNotification:(NSNotification *)notification
 {
-    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
+    #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && !__has_feature(attribute_availability_app_extension)
 
     if ([[notification name] isEqualToString:UIApplicationDidReceiveMemoryWarningNotification]) {
         if (self.removeAllObjectsOnMemoryWarning)


### PR DESCRIPTION
Provides better support for CocoaPods 0.36 which builds static libraries using the same compiler flags as the target being compiled for.