### PR TITLE
Fixes issue where byteCount of the disk cache being the wrong if the setObject:forKey methods are called for a key that already in the cache (i.e. updating the object for a key)

### DIFF
--- a/TMCache/TMDiskCache.m
+++ b/TMCache/TMDiskCache.m
@@ -493,8 +493,9 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
             if (diskFileSize) {
                 NSNumber *oldEntry = [strongSelf->_sizes objectForKey:key];
                 
-                if ([oldEntry isKindOfClass:[NSNumber class]])
+                if ([oldEntry isKindOfClass:[NSNumber class]]){
                     strongSelf.byteCount = strongSelf->_byteCount - [oldEntry unsignedIntegerValue];
+                }
                 
                 [strongSelf->_sizes setObject:diskFileSize forKey:key];
                 strongSelf.byteCount = strongSelf->_byteCount + [diskFileSize unsignedIntegerValue]; // atomic

--- a/TMCache/TMDiskCache.m
+++ b/TMCache/TMDiskCache.m
@@ -491,6 +491,11 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
 
             NSNumber *diskFileSize = [values objectForKey:NSURLTotalFileAllocatedSizeKey];
             if (diskFileSize) {
+                NSNumber *oldEntry = [strongSelf->_sizes objectForKey:key];
+                
+                if ([oldEntry isKindOfClass:[NSNumber class]])
+                    strongSelf.byteCount = strongSelf->_byteCount - [oldEntry unsignedIntegerValue];
+                
                 [strongSelf->_sizes setObject:diskFileSize forKey:key];
                 strongSelf.byteCount = strongSelf->_byteCount + [diskFileSize unsignedIntegerValue]; // atomic
             }


### PR DESCRIPTION
Closes https://github.com/tumblr/TMCache/issues/42 and https://github.com/tumblr/TMCache/issues/79