### PR TITLE
Factor out references to UIApplication

### DIFF
--- a/TMCache.podspec
+++ b/TMCache.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'TMCache'
-  s.version       = '1.2.4'
+  s.version       = '2.0.0'
   s.source_files  = 'TMCache/*.{h,m}'
   s.homepage      = 'https://github.com/tumblr/TMCache'
   s.summary       = 'Fast parallel object cache for iOS and OS X.'

--- a/TMCache/TMCacheBackgroundTaskManager.h
+++ b/TMCache/TMCacheBackgroundTaskManager.h
@@ -8,10 +8,25 @@
 
 @import UIKit;
 
+/**
+ A protocol that classes who can begin and end background tasks can conform to. This protocol provides an abstraction in
+ order to avoid referencing `+ [UIApplication sharedApplication]` from within an iOS application extension.
+ */
 @protocol TMCacheBackgroundTaskManager <NSObject>
 
+/**
+ Marks the beginning of a new long-running background task.
+ 
+ @return A unique identifier for the new background task. You must pass this value to the `endBackgroundTask:` method to
+ mark the end of this task. This method returns `UIBackgroundTaskInvalid` if running in the background is not possible.
+ */
 - (UIBackgroundTaskIdentifier)beginBackgroundTask;
 
+/**
+ Marks the end of a specific long-running background task.
+ 
+ @param identifier An identifier returned by the `beginBackgroundTaskWithExpirationHandler:` method.
+ */
 - (void)endBackgroundTask:(UIBackgroundTaskIdentifier)identifier;
 
 @end

--- a/TMCache/TMCacheBackgroundTaskManager.h
+++ b/TMCache/TMCacheBackgroundTaskManager.h
@@ -8,6 +8,10 @@
 
 @import UIKit;
 
+#ifndef __IPHONE_OS_VERSION_MIN_REQUIRED
+typedef NSUInteger UIBackgroundTaskIdentifier;
+#endif
+
 /**
  A protocol that classes who can begin and end background tasks can conform to. This protocol provides an abstraction in
  order to avoid referencing `+ [UIApplication sharedApplication]` from within an iOS application extension.

--- a/TMCache/TMCacheBackgroundTaskManager.h
+++ b/TMCache/TMCacheBackgroundTaskManager.h
@@ -8,7 +8,7 @@
 
 @import UIKit;
 
-#ifndef __IPHONE_OS_VERSION_MIN_REQUIRED
+#ifndef UIBackgroundTaskIdentifier
 typedef NSUInteger UIBackgroundTaskIdentifier;
 #endif
 

--- a/TMCache/TMCacheBackgroundTaskManager.h
+++ b/TMCache/TMCacheBackgroundTaskManager.h
@@ -1,0 +1,17 @@
+//
+//  TMCacheBackgroundTaskManager.h
+//  TMCache
+//
+//  Created by Bryan Irace on 4/24/15.
+//  Copyright (c) 2015 Tumblr. All rights reserved.
+//
+
+@import UIKit;
+
+@protocol TMCacheBackgroundTaskManager <NSObject>
+
+- (UIBackgroundTaskIdentifier)beginBackgroundTask;
+
+- (void)endBackgroundTask:(UIBackgroundTaskIdentifier)identifier;
+
+@end

--- a/TMCache/TMDiskCache.h
+++ b/TMCache/TMDiskCache.h
@@ -340,6 +340,11 @@ typedef void (^TMDiskCacheObjectBlock)(TMDiskCache *cache, NSString *key, id <NS
 #pragma mark -
 /// @name Background Tasks
 
+/**
+ Set a global manager to be used for setting up/tearing down any background tasks needed by TMCache.
+ 
+ @param backgroundTaskManager Background task manager.
+ */
 + (void)setBackgroundTaskManager:(id <TMCacheBackgroundTaskManager>)backgroundTaskManager;
 
 @end

--- a/TMCache/TMDiskCache.h
+++ b/TMCache/TMDiskCache.h
@@ -26,6 +26,7 @@
 #import <Foundation/Foundation.h>
 
 @class TMDiskCache;
+@protocol TMCacheBackgroundTaskManager;
 
 typedef void (^TMDiskCacheBlock)(TMDiskCache *cache);
 typedef void (^TMDiskCacheObjectBlock)(TMDiskCache *cache, NSString *key, id <NSCoding> object, NSURL *fileURL);
@@ -335,5 +336,10 @@ typedef void (^TMDiskCacheObjectBlock)(TMDiskCache *cache, NSString *key, id <NS
  Instead use the asynchronous version, <enumerateObjectsWithBlock:completionBlock:>.
  */
 - (void)enumerateObjectsWithBlock:(TMDiskCacheObjectBlock)block;
+
+#pragma mark -
+/// @name Background Tasks
+
++ (void)setBackgroundTaskManager:(id <TMCacheBackgroundTaskManager>)backgroundTaskManager;
 
 @end

--- a/TMCache/TMDiskCache.m
+++ b/TMCache/TMDiskCache.m
@@ -1,4 +1,5 @@
 #import "TMDiskCache.h"
+#import "TMCacheBackgroundTaskManager.h"
 
 #if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0
 #import <UIKit/UIKit.h>
@@ -8,15 +9,7 @@
                                     [[NSString stringWithUTF8String:__FILE__] lastPathComponent], \
                                     __LINE__, [error localizedDescription]); }
 
-#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_4_0 && defined(__clang) && defined(__has_feature) && !__has_feature(attribute_availability_app_extension)
-    #define TMCacheStartBackgroundTask() UIBackgroundTaskIdentifier taskID = UIBackgroundTaskInvalid; \
-            taskID = [[UIApplication sharedApplication] beginBackgroundTaskWithExpirationHandler:^{ \
-            [[UIApplication sharedApplication] endBackgroundTask:taskID]; }];
-    #define TMCacheEndBackgroundTask() [[UIApplication sharedApplication] endBackgroundTask:taskID];
-#else
-    #define TMCacheStartBackgroundTask()
-    #define TMCacheEndBackgroundTask()
-#endif
+static id <TMCacheBackgroundTaskManager> TMCacheBackgroundTaskManager;
 
 NSString * const TMDiskCachePrefix = @"com.tumblr.TMDiskCache";
 NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
@@ -210,7 +203,7 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
 
 + (void)emptyTrash
 {
-    TMCacheStartBackgroundTask();
+    UIBackgroundTaskIdentifier taskID = [TMCacheBackgroundTaskManager beginBackgroundTask];
     
     dispatch_async([self sharedTrashQueue], ^{        
         NSError *error = nil;
@@ -225,8 +218,8 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
             [[NSFileManager defaultManager] removeItemAtURL:trashedItemURL error:&error];
             TMDiskCacheError(error);
         }
-            
-        TMCacheEndBackgroundTask();
+        
+        [TMCacheBackgroundTaskManager endBackgroundTask:taskID];
     });
 }
 
@@ -464,14 +457,14 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
     if (!key || !object)
         return;
 
-    TMCacheStartBackgroundTask();
+    UIBackgroundTaskIdentifier taskID = [TMCacheBackgroundTaskManager beginBackgroundTask];
 
     __weak TMDiskCache *weakSelf = self;
 
     dispatch_async(_queue, ^{
         TMDiskCache *strongSelf = weakSelf;
         if (!strongSelf) {
-            TMCacheEndBackgroundTask();
+            [TMCacheBackgroundTaskManager endBackgroundTask:taskID];
             return;
         }
 
@@ -513,7 +506,7 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
         if (block)
             block(strongSelf, key, object, fileURL);
 
-        TMCacheEndBackgroundTask();
+        [TMCacheBackgroundTaskManager endBackgroundTask:taskID];
     });
 }
 
@@ -522,14 +515,14 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
     if (!key)
         return;
 
-    TMCacheStartBackgroundTask();
+    UIBackgroundTaskIdentifier taskID = [TMCacheBackgroundTaskManager beginBackgroundTask];
 
     __weak TMDiskCache *weakSelf = self;
 
     dispatch_async(_queue, ^{
         TMDiskCache *strongSelf = weakSelf;
         if (!strongSelf) {
-            TMCacheEndBackgroundTask();
+            [TMCacheBackgroundTaskManager endBackgroundTask:taskID];
             return;
         }
 
@@ -539,7 +532,7 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
         if (block)
             block(strongSelf, key, nil, fileURL);
 
-        TMCacheEndBackgroundTask();
+        [TMCacheBackgroundTaskManager endBackgroundTask:taskID];
     });
 }
 
@@ -550,14 +543,14 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
         return;
     }
 
-    TMCacheStartBackgroundTask();
+    UIBackgroundTaskIdentifier taskID = [TMCacheBackgroundTaskManager beginBackgroundTask];
     
     __weak TMDiskCache *weakSelf = self;
     
     dispatch_async(_queue, ^{
         TMDiskCache *strongSelf = weakSelf;
         if (!strongSelf) {
-            TMCacheEndBackgroundTask();
+            [TMCacheBackgroundTaskManager endBackgroundTask:taskID];
             return;
         }
 
@@ -566,7 +559,7 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
         if (block)
             block(strongSelf);
         
-        TMCacheEndBackgroundTask();
+        [TMCacheBackgroundTaskManager endBackgroundTask:taskID];
     });
 }
 
@@ -580,14 +573,14 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
         return;
     }
     
-    TMCacheStartBackgroundTask();
+    UIBackgroundTaskIdentifier taskID = [TMCacheBackgroundTaskManager beginBackgroundTask];
 
     __weak TMDiskCache *weakSelf = self;
 
     dispatch_async(_queue, ^{
         TMDiskCache *strongSelf = weakSelf;
         if (!strongSelf) {
-            TMCacheEndBackgroundTask();
+            [TMCacheBackgroundTaskManager endBackgroundTask:taskID];
             return;
         }
 
@@ -596,7 +589,7 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
         if (block)
             block(strongSelf);
         
-        TMCacheEndBackgroundTask();
+        [TMCacheBackgroundTaskManager endBackgroundTask:taskID];
     });
 }
 
@@ -607,14 +600,14 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
         return;
     }
 
-    TMCacheStartBackgroundTask();
+    UIBackgroundTaskIdentifier taskID = [TMCacheBackgroundTaskManager beginBackgroundTask];
 
     __weak TMDiskCache *weakSelf = self;
 
     dispatch_async(_queue, ^{
         TMDiskCache *strongSelf = weakSelf;
         if (!strongSelf) {
-            TMCacheEndBackgroundTask();
+            [TMCacheBackgroundTaskManager endBackgroundTask:taskID];
             return;
         }
 
@@ -623,20 +616,20 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
         if (block)
             block(strongSelf);
 
-        TMCacheEndBackgroundTask();
+        [TMCacheBackgroundTaskManager endBackgroundTask:taskID];
     });
 }
 
 - (void)removeAllObjects:(TMDiskCacheBlock)block
 {
-    TMCacheStartBackgroundTask();
+    UIBackgroundTaskIdentifier taskID = [TMCacheBackgroundTaskManager beginBackgroundTask];
     
     __weak TMDiskCache *weakSelf = self;
 
     dispatch_async(_queue, ^{
         TMDiskCache *strongSelf = weakSelf;
         if (!strongSelf) {
-            TMCacheEndBackgroundTask();
+            [TMCacheBackgroundTaskManager endBackgroundTask:taskID];
             return;
         }
 
@@ -658,7 +651,7 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
         if (block)
             block(strongSelf);
         
-        TMCacheEndBackgroundTask();
+        [TMCacheBackgroundTaskManager endBackgroundTask:taskID];
     });
 }
 
@@ -667,14 +660,14 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
     if (!block)
         return;
 
-    TMCacheStartBackgroundTask();
+    UIBackgroundTaskIdentifier taskID = [TMCacheBackgroundTaskManager beginBackgroundTask];
 
     __weak TMDiskCache *weakSelf = self;
 
     dispatch_async(_queue, ^{
         TMDiskCache *strongSelf = weakSelf;
         if (!strongSelf) {
-            TMCacheEndBackgroundTask();
+            [TMCacheBackgroundTaskManager endBackgroundTask:taskID];
             return;
         }
 
@@ -688,7 +681,7 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
         if (completionBlock)
             completionBlock(strongSelf);
 
-        TMCacheEndBackgroundTask();
+        [TMCacheBackgroundTaskManager endBackgroundTask:taskID];
     });
 }
 
@@ -1059,6 +1052,12 @@ NSString * const TMDiskCacheSharedName = @"TMDiskCacheShared";
         
         [strongSelf trimToAgeLimitRecursively];
     });
+}
+
+#pragma mark - Background Tasks -
+
++ (void)setBackgroundTaskManager:(id <TMCacheBackgroundTaskManager>)backgroundTaskManager {
+    TMCacheBackgroundTaskManager = backgroundTaskManager;
 }
 
 @end

--- a/TMCache/TMMemoryCache.h
+++ b/TMCache/TMMemoryCache.h
@@ -297,4 +297,8 @@ typedef void (^TMMemoryCacheObjectBlock)(TMMemoryCache *cache, NSString *key, id
  */
 - (void)enumerateObjectsWithBlock:(TMMemoryCacheObjectBlock)block;
 
+- (void)handleMemoryWarning;
+
+- (void)handleApplicationBackgrounding;
+
 @end

--- a/tests/TMCache.xcodeproj/project.pbxproj
+++ b/tests/TMCache.xcodeproj/project.pbxproj
@@ -66,6 +66,7 @@
 		662900141A66B60D009C10BD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		6629FFED1A66B512009C10BD /* TMCache.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = TMCache.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6629FFF01A66B512009C10BD /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		93E151CE1AEA960B00CCD447 /* TMCacheBackgroundTaskManager.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = TMCacheBackgroundTaskManager.h; sourceTree = "<group>"; };
 		D07F1EB2171AFB7A001DBA02 /* TMCache.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = TMCache.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		D07F1EB5171AFB7A001DBA02 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = System/Library/Frameworks/UIKit.framework; sourceTree = SDKROOT; };
 		D07F1EB7171AFB7A001DBA02 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = System/Library/Frameworks/Foundation.framework; sourceTree = SDKROOT; };
@@ -239,6 +240,7 @@
 				D0E5D83D171DF0AF0041E777 /* TMDiskCache.m */,
 				D0E5D83E171DF0AF0041E777 /* TMMemoryCache.h */,
 				D0E5D83F171DF0AF0041E777 /* TMMemoryCache.m */,
+				93E151CE1AEA960B00CCD447 /* TMCacheBackgroundTaskManager.h */,
 			);
 			name = TMCache;
 			path = ../TMCache;
@@ -764,6 +766,7 @@
 				662900081A66B513009C10BD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		6629002A1A66B60D009C10BD /* Build configuration list for PBXNativeTarget "OS X" */ = {
 			isa = XCConfigurationList;
@@ -772,6 +775,7 @@
 				6629002C1A66B60D009C10BD /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		D07F1EAD171AFB7A001DBA02 /* Build configuration list for PBXProject "TMCache" */ = {
 			isa = XCConfigurationList;


### PR DESCRIPTION
Turns out my [previous attempt](https://github.com/tumblr/TMCache/pull/81) at this – conditional compilation – was misguided. Instead, let’s just remove background task creation and memory warning/background notification observation from this library altogether and provide a way for applications to hook-in and provide it themselves.