### PR TITLE
Add back notification observation that was stupidly removed in 2.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+### 2.1 -- 2015 May 8 ###
+
+Removes the need for the explicit memory warning and application background handling, which was an ill-advised change in 2.0.
+
+The other part of the 2.0 release still applies; you need to explicitly provide an object that knows how to vend background tasks in order for operations to continue after your application has been backgrounded.
+
 ### 2.0.0 -- 2015 April 27 ###
 
 2.0.0 removes all references to `UIApplication sharedApplication`. As of iOS 8, this method is annotated with `NS_EXTENSION_UNAVAILABLE_IOS`, meaning that it won’t compile as part of an iOS 8 extension. In order to facilitate `TMCache` usage inside extensions.

--- a/TMCache.podspec
+++ b/TMCache.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'TMCache'
-  s.version       = '3.0.0'
+  s.version       = '2.1.0'
   s.source_files  = 'TMCache/*.{h,m}'
   s.homepage      = 'https://github.com/tumblr/TMCache'
   s.summary       = 'Fast parallel object cache for iOS and OS X.'

--- a/TMCache.podspec
+++ b/TMCache.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name          = 'TMCache'
-  s.version       = '2.0.0'
+  s.version       = '3.0.0'
   s.source_files  = 'TMCache/*.{h,m}'
   s.homepage      = 'https://github.com/tumblr/TMCache'
   s.summary       = 'Fast parallel object cache for iOS and OS X.'

--- a/TMCache/TMMemoryCache.h
+++ b/TMCache/TMMemoryCache.h
@@ -297,4 +297,14 @@ typedef void (^TMMemoryCacheObjectBlock)(TMMemoryCache *cache, NSString *key, id
  */
 - (void)enumerateObjectsWithBlock:(TMMemoryCacheObjectBlock)block;
 
+/**
+ Handle a memory warning.
+ */
+- (void)handleMemoryWarning __deprecated_msg("This happens automatically in TMCache 2.1. There’s no longer a need to call it directly.");
+
+/**
+ Handle the application having been backgrounded.
+ */
+- (void)handleApplicationBackgrounding __deprecated_msg("This happens automatically in TMCache 2.1. There’s no longer a need to call it directly.");
+
 @end

--- a/TMCache/TMMemoryCache.h
+++ b/TMCache/TMMemoryCache.h
@@ -297,8 +297,4 @@ typedef void (^TMMemoryCacheObjectBlock)(TMMemoryCache *cache, NSString *key, id
  */
 - (void)enumerateObjectsWithBlock:(TMMemoryCacheObjectBlock)block;
 
-- (void)handleMemoryWarning;
-
-- (void)handleApplicationBackgrounding;
-
 @end


### PR DESCRIPTION
I removed the observing of memory warning and application backgrounding notifications in [this commit](https://github.com/tumblr/TMCache/commit/f2be8c6f68ebb8d1b4ceaa6e183294e3bce6d80a), due to references to `[UIApplication sharedApplication]` (which can’t be used in an iOS 8 extension). Of course, what I _should’ve done is keep observing the notifications regardless of what object they come from.

Fixing this oversight which unfortunately means going to 3.0.0 but ~\*~ such is semver ~\*~.

Thank you @studentdeng for calling me out on this and @segiddins for proposing the correct fix: https://github.com/tumblr/TMCache/issues/85